### PR TITLE
modify read.nhx to take a connection so that it can be fed tree strings

### DIFF
--- a/R/NHX.R
+++ b/R/NHX.R
@@ -16,7 +16,7 @@ read.nhx <- function(file) {
     }
     treetext %<>% gsub(" ", "",. )
     
-    phylo <- read.tree(file)
+    phylo <- read.tree( text = treetext )
     nnode <- phylo$Nnode + Ntip(phylo)
     nlab <- paste("X", 1:nnode, sep="")
     tree2 <- treetext
@@ -52,7 +52,7 @@ read.nhx <- function(file) {
     nhx_stats$node <- node
     
     new("nhx",
-        file = file,
+        file = treetext,
         fields = fields,
         phylo = phylo,
         nhx_tags = nhx_stats


### PR DESCRIPTION
`read.nhx` could only take a file path, specified with `file`. This is then used three times:

- In `readLines(file)` to parse the tree text
- In `phylo <- read.tree(file)` to parse the file as a tree
- In `file = file` to put the path into a character slot in the new object

This means that `file` must be a character string that specifies a path. Often, though, the user would like to read the tree from a string instead. This could be accomplished if `file` could be a connection. The user could then create a text connection and pass that, eg `nhx = read.nhx( textConnection( nhx_text ) )`.

`readLines()` can take a path or connection as `file`. So it is OK as-is. `file` should only be used here. I therefore made the following two modifications:

- Use the parsed tree string used to generate `phylo` with `phylo <- read.tree( text = treetext)`
- Instead of putting the path in the `nhx` slot, put in the treetext with `file = treetext`