### PR TITLE
Fix gheatmap with single column

### DIFF
--- a/R/gheatmap.R
+++ b/R/gheatmap.R
@@ -26,27 +26,28 @@
 ##' @author Guangchuang Yu
 gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color="white",
                      colnames=TRUE, colnames_position="bottom", colnames_level=NULL, font.size=4) {
-
+    
     colnames_position %<>% match.arg(c("bottom", "top"))
     variable <- value <- lab <- y <- NULL
     
     ## if (is.null(width)) {
     ##     width <- (p$data$x %>% range %>% diff)/30
     ## }
-
+    
     ## convert width to width of each cell
     width <- width * (p$data$x %>% range %>% diff) / ncol(data)
     
     isTip <- x <- y <- variable <- value <- from <- to <- NULL
- 
+    
     df <- p$data
     df <- df[df$isTip,]
     start <- max(df$x) + offset
-
-    dd <- data[df$label[order(df$y)],]
-    dd$y <- sort(df$y)
-
+    
+    dd <- data
     dd$lab <- rownames(dd)
+    dd <- dd[df$label[order(df$y)],]
+    dd$y <- sort(df$y)
+    
     ## dd <- melt(dd, id=c("lab", "y"))
     dd <- gather(dd, variable, value, -c(lab, y))
     
@@ -61,13 +62,14 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
     V2 <- start + as.numeric(dd$variable) * width
     mapping <- data.frame(from=dd$variable, to=V2)
     mapping <- unique(mapping)
-
+    
     dd$x <- V2
-
+    dd$width <- width
+    
     if (is.null(color)) {
-        p2 <- p + geom_tile(data=dd, aes(x, y, fill=value), inherit.aes=FALSE)
+        p2 <- p + geom_tile(data=dd, aes(x, y, fill=value, width=width), inherit.aes=FALSE)
     } else {
-        p2 <- p + geom_tile(data=dd, aes(x, y, fill=value), color=color, inherit.aes=FALSE)
+        p2 <- p + geom_tile(data=dd, aes(x, y, fill=value, width=width), color=color, inherit.aes=FALSE)
     }
     if (is(dd$value,"numeric")) {
         p2 <- p2 + scale_fill_gradient(low=low, high=high, na.value="white")
@@ -83,7 +85,7 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
         }
         p2 <- p2 + geom_text(data=mapping, aes(x=to, label=from), y=y, size=font.size, inherit.aes = FALSE)
     }
-
+    
     p2 <- p2 + theme(legend.position="right", legend.title=element_blank())
     p2 <- p2 + guides(fill = guide_legend(override.aes = list(colour = NULL)))
     


### PR DESCRIPTION
Fix for gheatmap, now allows plotting a heatmap consisting of a single column (while respecting width attribute) - See issue #52

+ The problem was that reordering rows of heatmap data based on the labels stored in `p` was converting `data.frames` that only had 1 row to a vector. 
+ Once the above was fixed also had an issue with defining the width of the columns of the heatmap 
as the default width provided by ggplot made the columns unduly wide. 

![image](https://cloud.githubusercontent.com/assets/452422/15117650/86cb422e-15d6-11e6-8356-c1050ebed85e.png)


Signed-off-by: Justin Silverman <jsilve24@gmail.com>
