### PR TITLE
Fixed internal node numbering in drop.tip()

### DIFF
--- a/R/method-drop-tip.R
+++ b/R/method-drop-tip.R
@@ -35,9 +35,10 @@ setMethod("drop.tip", signature(object="nhx"),
 
               ## Update tip node numbers
               tip_nodes <- object@nhx_tags$node.label[ object@nhx_tags$is_tip ]
-              internal_nodes <- object@nhx_tags$node.label[ !object@nhx_tags$is_tip ]
               object@nhx_tags$node[ object@nhx_tags$is_tip ] = match(object@phylo$tip.label, tip_nodes)
-              object@nhx_tags$node[ !object@nhx_tags$is_tip ] = match(object@phylo$node.label, internal_nodes)
+
+              internal_nodes <- object@nhx_tags$node.label[ !object@nhx_tags$is_tip ]
+              object@nhx_tags$node[ !object@nhx_tags$is_tip ] = match(object@phylo$node.label, internal_nodes) + length(object@phylo$tip.label)
 
               ## Clean up
               object@nhx_tags$node.label = NULL

--- a/tests/testthat/test-nhx.R
+++ b/tests/testthat/test-nhx.R
@@ -78,13 +78,20 @@ test_that("can parse phyldog nhx tree string", {
 
 test_that("can drop tips", {
 	nhx <- read.nhx( textConnection(test_phyldog_nhx_text) )
-        to_drop = c("Physonect_sp_@2066767", "Lychnagalma_utricularia@2253871", "Kephyes_ovata@2606431")
+	to_drop = c("Physonect_sp_@2066767", "Lychnagalma_utricularia@2253871", "Kephyes_ovata@2606431")
 
 	nhx_reduced = drop.tip(nhx, to_drop)
 
 	# Make sure node numbers unique
 	expect_false( any(duplicated(nhx_reduced@nhx_tags$node)) )
 
+	# Make sure the same node numbers are present in @nhx_tag and @phylo
+	edge = nhx_reduced@phylo$edge
+	dim(edge) = NULL
+	edge = unique(edge)
+	expect_true( setequal( edge, nhx_reduced@nhx_tags$node ) )
+
+	# Check the expected number of tips after dropping
 	expect_equal( length(nhx_reduced@phylo$tip.label), 13 )
-        expect_true( all(nhx_reduced@nhx_tags$node %in% fortify(nhx_reduced)$node) )
+	expect_true( all(nhx_reduced@nhx_tags$node %in% fortify(nhx_reduced)$node) )
 })

--- a/tests/testthat/test-nhx.R
+++ b/tests/testthat/test-nhx.R
@@ -81,6 +81,10 @@ test_that("can drop tips", {
         to_drop = c("Physonect_sp_@2066767", "Lychnagalma_utricularia@2253871", "Kephyes_ovata@2606431")
 
 	nhx_reduced = drop.tip(nhx, to_drop)
+
+	# Make sure node numbers unique
+	expect_false( any(duplicated(nhx_reduced@nhx_tags$node)) )
+
 	expect_equal( length(nhx_reduced@phylo$tip.label), 13 )
         expect_true( all(nhx_reduced@nhx_tags$node %in% fortify(nhx_reduced)$node) )
 })


### PR DESCRIPTION
Internal nodes in `@nhx_tags$node` were numbered from 1, rather than consecutively after the tip nodes. This led to different nodes having the same node number, and the internal node numbers not corresponding between `@nhx_tags$node` and `@phylo`. Added an offset to fix this, and now test that same nodes are present in `@nhx_tags$node` and `@phylo$edge()`.