### PR TITLE
Add legend transparency to theme_transparent

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -96,10 +96,10 @@ theme_transparent <- function(...) {
               colour = NA), ...),
           legend.key = element_rect(
               fill = "transparent", 
-              colour = NA, ...),
+              colour = NA), ...),
           legend.background = element_rect(
               fill = "transparent", 
-              colour = NA, ...)
+              colour = NA), ...)
 }
 
 ##' inset theme

--- a/R/theme.R
+++ b/R/theme.R
@@ -93,10 +93,10 @@ theme_transparent <- function(...) {
               colour = NA),
           plot.background = element_rect(
               fill = "transparent",
-              colour = NA), ...),
+              colour = NA),
           legend.key = element_rect(
               fill = "transparent", 
-              colour = NA), ...),
+              colour = NA),
           legend.background = element_rect(
               fill = "transparent", 
               colour = NA), ...)

--- a/R/theme.R
+++ b/R/theme.R
@@ -93,7 +93,13 @@ theme_transparent <- function(...) {
               colour = NA),
           plot.background = element_rect(
               fill = "transparent",
-              colour = NA), ...)
+              colour = NA), ...),
+          legend.key = element_rect(
+              fill = "transparent", 
+              colour = NA, ...),
+          legend.background = element_rect(
+              fill = "transparent", 
+              colour = NA, ...)
 }
 
 ##' inset theme


### PR DESCRIPTION
Right now, if a legend is added to the plot with 

```r
p + theme_transparent(legend.position='right')
```

the plot won't have a fully transparent background because of the legend. This commit proposes a fix for that.

You may argue that this is not the job of this theme. If users add a legend, they can as well tweak the theme for their own needs.

However, I think having a fully transparent theme falls within the expectation of the user when using this theme.