### PR TITLE
Fix examples with `sample.nwk`

### DIFF
--- a/R/experimental_function.R
+++ b/R/experimental_function.R
@@ -156,7 +156,7 @@ scale_x_ggtree <- function(tree_view, breaks=NULL, labels=NULL) {
 ## ##' @export
 ## ##' @author Guangchuang Yu \url{http://ygc.name}
 ## ##' @examples
-## ##' nwk <- system.file("extdata", "sample.nwk", package="ggtree")
+## ##' nwk <- system.file("extdata", "sample.nwk", package="treeio")
 ## ##' tree <- read.tree(nwk)
 ## ##' p <- ggtree(tree)
 ## ##' d <- matrix(abs(rnorm(52)), ncol=4)

--- a/R/operator.R
+++ b/R/operator.R
@@ -10,7 +10,7 @@
 ##' @author Yu Guangchuang
 ##' @examples
 ##' library("ggplot2")
-##' nwk <- system.file("extdata", "sample.nwk", package="ggtree")
+##' nwk <- system.file("extdata", "sample.nwk", package="treeio")
 ##' tree <- read.tree(nwk)
 ##' p <- ggtree(tree) + geom_tippoint(color="#b5e521", alpha=1/4, size=10)
 ##' p %<% rtree(30)
@@ -32,7 +32,7 @@
 ##' @export
 ##' @author Yu Guangchuang
 ##' @examples
-##' nwk <- system.file("extdata", "sample.nwk", package="ggtree")
+##' nwk <- system.file("extdata", "sample.nwk", package="treeio")
 ##' tree <- read.tree(nwk)
 ##' p <- ggtree(tree)
 ##' dd <- data.frame(taxa=LETTERS[1:13],


### PR DESCRIPTION
Hello!
This PR will fix the examples with `%<%` and `%<+%` operators, and experimental function `gplot`.

Currently, `nwk <- system.file("extdata", "sample.nwk", package="ggtree")` returns an empty string and the consequent `ape::read.tree` tries to read the tree as input from the keyboard. Hence, the examples doesn't work.

Thank you for the great package!
With best regards,
Vladimir
