### PR TITLE
 Add missing layout value in geom_tree docs 

### DIFF
--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -4,7 +4,7 @@
 ##' @title geom_tree
 ##' @param mapping aesthetic mapping
 ##' @param data data
-##' @param layout one of 'rectangular', 'slanted', 'circular', 'radial', 'equal_angle' or 'daylight'
+##' @param layout one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle' or 'daylight'
 ##' @param multiPhylo logical
 ##' @param ... additional parameter
 ##' @return tree layer

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -2,10 +2,8 @@
 ##'
 ##'
 ##' @title ggtree
+##' @inheritParams geom_tree
 ##' @param tr phylo object
-##' @param mapping aes mapping
-##' @param layout one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle' or 'daylight'
-##' @param open.angle open angle, only for 'fan' layout
 ##' @param mrsd most recent sampling date
 ##' @param as.Date logical whether using Date class in time tree
 ##' @param yscale y scale
@@ -15,7 +13,6 @@
 ##' @param right logical. If \code{ladderize = TRUE}, should the ladder have the smallest clade on the
 ##' right-hand side? See \code{\link[ape]{ladderize}} for more information. 
 ##' @param branch.length variable for scaling branch, if 'none' draw cladogram
-##' @param ... additional parameter
 ##' @return tree
 ##' @importFrom ggplot2 ggplot
 ##' @importFrom ggplot2 xlab


### PR DESCRIPTION
- Add missing possible value (`fan`) for layout in geom_tree documentation
- The code now uses a recent feature of roxygen2 to make sure that the documentation for `ggtree()` and `geom_tree()` are always in sync

I could not rebuild the docs so I leave this to you.