### PR TITLE
Reroot treedata

### DIFF
--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -22,3 +22,12 @@ setMethod("reroot", signature(object="phylo"),
               return(tree)
           })
 
+
+##' @method reroot treedata
+##' @export
+reroot.treedata <- function(object, node, ...) {
+    tree <- object@phylo
+    tree <- reroot(tree, node, ...)
+    object@phylo <- tree
+    object
+}

--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -27,13 +27,24 @@ setMethod("reroot", signature(object="phylo"),
 ##' @exportMethod reroot
 setMethod("reroot", signature(object="treedata"),
         function(object, node, ...) {
-        	# reroot tree
-            tree <- object@phylo
+        	# warning message
+        	message("The use of this method may cause some node data to become incorrect (e.g. bootstrap values).")
+        	
+        	# ensure nodes/tips have a label to properly map @anc_seq/@tip_seq
+        	tree <- object@phylo
+        	if (is.null(tree$tip.label)) {
+        		tree$tip.label <- as.character(1:Ntip(tree))
+        	}
+        	if (is.null(tree$node.label)) {
+        		tree$node.label <- as.character((1:tree$Nnode) + Ntip(tree))
+        	}
+        	
+            # reroot tree
             tree <- reroot(tree, node, ...)
             object@phylo <- tree
             
             # update node numbers in data
-            n.tips <- length(tree$tip.label) # Is there a better way in ggtree/treeio to get the number of tips?
+            n.tips <- Ntip(tree)
             node_map <- attr(tree, "node_map")
             data <- object@data
             data$node[match(node_map$from, as.integer(data$node))] <- node_map$to

--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -23,11 +23,21 @@ setMethod("reroot", signature(object="phylo"),
           })
 
 
-##' @method reroot treedata
-##' @export
-reroot.treedata <- function(object, node, ...) {
-    tree <- object@phylo
-    tree <- reroot(tree, node, ...)
-    object@phylo <- tree
-    object
-}
+##' @rdname reroot-methods
+##' @exportMethod reroot
+setMethod("reroot", signature(object="treedata"),
+        function(object, node, ...) {
+        	# reroot tree
+            tree <- object@phylo
+            tree <- reroot(tree, node, ...)
+            object@phylo <- tree
+            
+            # update node numbers in data
+            n.tips <- length(tree$tip.label) # Is there a better way in ggtree/treeio to get the number of tips?
+            node_map <- attr(tree, "node_map")
+            data <- object@data
+            data$node[match(node_map$from, as.integer(data$node))] <- node_map$to
+            object@data <- data
+            
+            return(object)
+        })


### PR DESCRIPTION
Hello Yu,

I've implemented the `reroot` function for the `treedata` class. Below is an example.

```r
library(ape)
library(phytools)
library(ggtree)
file <- system.file("extdata/BEAST", "beast_mcc.tree", package="treeio")
beast <- read.beast(file)
beast2 <- reroot(beast, 28)
multiplot(
    ggtree(beast) + geom_tiplab(aes(label=label)) + geom_tippoint(aes(subset=posterior==1)),
    ggtree(beast2) + geom_tiplab(aes(label=label)) + geom_tippoint(aes(subset=posterior==1)),
    ncol=2
)
```

I have noticed one problem with my implementation however. When the `reroot` function is first called it loads the ape and phytools packages which then override the `reroot` function causing further invocations to call `ape::reroot`. I am not sure how to fix this without loading ape and phytools first or using `ggtree::reroot`.