### PR TITLE
Add crosslinks between geom_tiplab / geom_tiplab2 and geom_cladelabel/geom_cladelabel2

### DIFF
--- a/R/geom_cladelabel.R
+++ b/R/geom_cladelabel.R
@@ -12,7 +12,7 @@
 ##' @param fontsize size of text
 ##' @param angle angle of text
 ##' @param geom one of 'text' or 'label'
-##' @param hjust hjust
+##' @param hjust justify text horizontally
 ##' @param color color for clade & label, of length 1 or 2
 ##' @param fill fill label background, only work with geom='label'
 ##' @param family sans by default, can be any supported font
@@ -21,6 +21,7 @@
 ##' @return ggplot layers
 ##' @export
 ##' @author Guangchuang Yu
+##' @seealso \link{geom_cladelabel2}
 geom_cladelabel <- function(node, label,
                             offset      = 0,
                             offset.text = 0,

--- a/R/geom_cladelabel2.R
+++ b/R/geom_cladelabel2.R
@@ -2,25 +2,12 @@
 ##'
 ##'
 ##' @title geom_cladelabel2
-##' @param node selected node
-##' @param label clade label
-##' @param offset offset of bar and text from the clade
-##' @param offset.text offset of text from bar
+##' @inheritParams geom_cladelabel
 ##' @param offset.bar offset of bar from text
-##' @param align logical
-##' @param barsize size of bar
-##' @param fontsize font size of text
-## @param angle angle of text
-##' @param geom one of 'text' or 'label'
-##' @param hjust justify text horizontally
-##' @param color color for clade & label, of length 1 or 2
-## @param fill fill label background, only work with geom='label'
-##' @param family sans by default, can be any supported font
-##' @param parse logical, whether parse label
-##' @param ... additional parameter
 ##' @return ggplot layers
 ##' @export
 ##' @author JustGitting
+##' @seealso \link{geom_cladelabel}
 geom_cladelabel2 <- function(node, label, offset=0, offset.text=0, offset.bar=0,
                             align=FALSE, barsize=0.5, fontsize=3.88, hjust = 0,
                             geom="text",

--- a/R/geom_label.R
+++ b/R/geom_label.R
@@ -9,7 +9,7 @@
 ##' @param stat Name of stat to modify data
 ##' @param position The position adjustment to use for overlapping points on this layer
 ##' @param family sans by default, can be any supported font
-##' @param parse if TRUE, the labels will be passd into expressions
+##' @param parse if TRUE, the labels will be parsed as expressions
 ##' @param nudge_x horizontal adjustment
 ##' @param nudge_y vertical adjustment
 ##' @param label.padding Amount of padding around label.

--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -19,6 +19,7 @@
 ##' require(ape)
 ##' tr <- rtree(10)
 ##' ggtree(tr) + geom_tiplab()
+##' @seealso \link{geom_tiplab2}
 geom_tiplab <- function(mapping=NULL, hjust = 0,  align = FALSE, linetype = "dotted", linesize=0.5, geom="text",  offset=0, ...) {
     geom <- match.arg(geom, c("text", "label", "image", "phylopic"))
     if (geom == "text") {
@@ -84,6 +85,7 @@ geom_tiplab <- function(mapping=NULL, hjust = 0,  align = FALSE, linetype = "dot
 ##' @export
 ##' @author Guangchuang Yu
 ##' @references \url{https://groups.google.com/forum/#!topic/bioc-ggtree/o35PV3iHO-0}
+##' @seealso \link{geom_tiplab}
 geom_tiplab2 <- function(mapping=NULL, hjust=0, ...) {
     angle <- isTip <- node <- NULL
     m1 <- aes(subset=(isTip & (angle < 90 | angle > 270)), angle=angle, node = node)

--- a/man/geom_cladelabel.Rd
+++ b/man/geom_cladelabel.Rd
@@ -30,7 +30,7 @@ geom_cladelabel(node, label, offset = 0, offset.text = 0, extend = 0,
 
 \item{geom}{one of 'text' or 'label'}
 
-\item{hjust}{hjust}
+\item{hjust}{justify text horizontally}
 
 \item{color}{color for clade & label, of length 1 or 2}
 
@@ -47,6 +47,9 @@ ggplot layers
 }
 \description{
 annotate a clade with bar and text label
+}
+\seealso{
+\link{geom_cladelabel2}
 }
 \author{
 Guangchuang Yu

--- a/man/geom_cladelabel2.Rd
+++ b/man/geom_cladelabel2.Rd
@@ -24,7 +24,7 @@ geom_cladelabel2(node, label, offset = 0, offset.text = 0,
 
 \item{barsize}{size of bar}
 
-\item{fontsize}{font size of text}
+\item{fontsize}{size of text}
 
 \item{hjust}{justify text horizontally}
 
@@ -43,6 +43,9 @@ ggplot layers
 }
 \description{
 annotate a clade with bar and text label
+}
+\seealso{
+\link{geom_cladelabel}
 }
 \author{
 JustGitting

--- a/man/geom_label2.Rd
+++ b/man/geom_label2.Rd
@@ -24,7 +24,7 @@ only needed if you want to override the plot defaults.}
 
 \item{family}{sans by default, can be any supported font}
 
-\item{parse}{if TRUE, the labels will be passd into expressions}
+\item{parse}{if TRUE, the labels will be parsed as expressions}
 
 \item{nudge_x}{horizontal adjustment}
 

--- a/man/geom_tiplab.Rd
+++ b/man/geom_tiplab.Rd
@@ -36,6 +36,9 @@ require(ape)
 tr <- rtree(10)
 ggtree(tr) + geom_tiplab()
 }
+\seealso{
+\link{geom_tiplab2}
+}
 \author{
 Guangchuang Yu
 }

--- a/man/geom_tiplab2.Rd
+++ b/man/geom_tiplab2.Rd
@@ -22,6 +22,9 @@ add tip label for circular layout
 \references{
 \url{https://groups.google.com/forum/#!topic/bioc-ggtree/o35PV3iHO-0}
 }
+\seealso{
+\link{geom_tiplab}
+}
 \author{
 Guangchuang Yu
 }


### PR DESCRIPTION
It may not be obvious to users that there is a second function dedicated to circular/fan geometries. This increases discoverability.