### PR TITLE
optimize the angle of text in geom_cladelab and don't inherit the global aes in geom_cladelab and geom_taxalink

### DIFF
--- a/R/geom_cladelab.R
+++ b/R/geom_cladelab.R
@@ -148,7 +148,7 @@ geom_cladelab <- function(
                           parse=FALSE,
                           ...
                          ){
-    params <- list(...)
+    params <- list(inherit.aes=FALSE,...)
     structure(
               list(
                   data=data,

--- a/R/geom_taxalink.R
+++ b/R/geom_taxalink.R
@@ -53,7 +53,7 @@ geom_taxalink <- function(data=NULL,
     }
 
     
-    params <- list(...)
+    params <- list(inherit.aes=FALSE, ...)
     structure(list(data    = data,
                    mapping = mapping,
                    taxa1   = taxa1,

--- a/R/ggplot-add-utilities.R
+++ b/R/ggplot-add-utilities.R
@@ -53,6 +53,21 @@ choose_hilight_layer <- function(object, type){
     return (ly)
 }
 
+extract_all_aes_var <- function(mapping, rmvar=c("node", "subset")){
+    unlist(lapply(names(mapping)[!names(mapping) %in% rmvar], 
+                  function(i) get_aes_var(mapping, i)))
+}
+
+remapping <- function(mapping, samevars){
+    allvars <- extract_all_aes_var(mapping, rmvar=NULL)
+    samevars <- allvars[allvars %in% samevars]
+    tmpmap <- lapply(samevars, function(i) paste0(i, ".x"))
+    tmpmap <- do.call("aes_string", tmpmap)
+    names(tmpmap) <- names(mapping)[allvars %in% samevars]
+    mapping <- modifyList(mapping, tmpmap)
+    return(mapping)
+}
+
 build_cladelabel_df <- function(trdf, nodeids, label, offset, align, angle, horizontal){
     dat <- mapply(function(i, o, a, g, h){get_cladelabel_position(data=trdf, 
                                           node=i, 

--- a/R/ggplot-add-utilities.R
+++ b/R/ggplot-add-utilities.R
@@ -225,7 +225,7 @@ build_image_layer <- function(data, object, params){
                         )
     image_obj$data <- data
     image_default_aes <- list(image=NULL,imagesize=0.05, imagecolour=NULL, imagecolor=NULL,
-                              size=0.05, colour = NULL, angle = 0, alpha=1)
+                              size=0.05, colour = NULL, angle = 0, alpha=1, inherit.aes=FALSE)
     image_obj$mapping <- reset_mapping(defaultm=image_default_aes,
                                       inputm=object$mapping)
     ifelse(is.null(image_obj$mapping), 
@@ -247,7 +247,7 @@ build_text_layer <- function(data, object, params){
     text_default_aes <- list(textcolour="white", textcolor="white", textsize=3.88, 
                              fontsize=3.88, fontcolor="white", fontcolour="white", 
                              colour="white", size=3.88, angle=0, hjust=0.05, vjust=0.05,
-                            alpha=NA, family="", fontface=1, lineheight=1.2)
+                             alpha=NA, family="", fontface=1, lineheight=1.2, inherit.aes=FALSE)
     shadowtext_default_aes <- c(text_default_aes, list(bg.colour="black",bg.r=0.1))
     label_default_aes <- c(text_default_aes, list(fill="white"))
     text_obj$mapping <- switch(object$geom,

--- a/R/ggplot-add-utilities.R
+++ b/R/ggplot-add-utilities.R
@@ -225,7 +225,9 @@ build_image_layer <- function(data, object, params){
                         )
     image_obj$data <- data
     image_default_aes <- list(image=NULL,imagesize=0.05, imagecolour=NULL, imagecolor=NULL,
-                              size=0.05, colour = NULL, angle = 0, alpha=1, inherit.aes=FALSE)
+                              size=0.05, colour = NULL, angle = 0, alpha=1, inherit.aes=FALSE,
+                              nudge_x=0, nudge_y=0, na.rm = FALSE, by = "width", na.rm = FALSE,position = "identity",
+                              stat = "identity", .fun = NULL, image_fun = NULL, hjust = 0.5)
     image_obj$mapping <- reset_mapping(defaultm=image_default_aes,
                                       inputm=object$mapping)
     ifelse(is.null(image_obj$mapping), 
@@ -240,23 +242,29 @@ build_image_layer <- function(data, object, params){
     return(image_obj)
 }
 
-build_text_layer <- function(data, object, params){
+build_text_layer <- function(data, object, params, layout){
     text_obj <- list()
     text_obj$data <- data
     if (object$geom=="shadowtext"){label_geom <- get_fun_from_pkg("shadowtext", "geom_shadowtext")}
     text_default_aes <- list(textcolour="white", textcolor="white", textsize=3.88, 
                              fontsize=3.88, fontcolor="white", fontcolour="white", 
-                             colour="white", size=3.88, angle=0, hjust=0.05, vjust=0.05,
-                             alpha=NA, family="", fontface=1, lineheight=1.2, inherit.aes=FALSE)
-    shadowtext_default_aes <- c(text_default_aes, list(bg.colour="black",bg.r=0.1))
-    label_default_aes <- c(text_default_aes, list(fill="white"))
+                             colour="white", size=3.88, angle=0, hjust=0.5, vjust=0.5,
+                             alpha=NA, family="", fontface=1, lineheight=1.2, inherit.aes=FALSE,
+                             nudge_x=0, nudge_y=0, check_overlap=FALSE, show.legend=NA, na.rm=FALSE,
+                             stat="identity", position="identity")
+    shadowtext_default_aes <- c(text_default_aes, list(bg.colour="black", bg.r=0.1))
+    label_default_aes <- c(text_default_aes, list(fill="white", label.padding = unit(0.25, "lines"),
+                                                  label.r = unit(0.15, "lines"), label.size = 0.25))
     text_obj$mapping <- switch(object$geom,
                               text=reset_mapping(defaultm=text_default_aes, inputm=object$mapping),
                               label=reset_mapping(defaultm=label_default_aes, inputm=object$mapping),
                               shadowtext=reset_mapping(defaultm=shadowtext_default_aes, inputm=object$mapping)
                               )
-    ifelse(is.null(text_obj$mapping), text_obj$mapping <- aes_(x=~x, y=~y, label=~label, angle=~angle), 
-           text_obj$mapping <- modifyList(text_obj$mapping, aes_(x=~x, y=~y, label=~label, angle=~angle)))
+    if(length(text_obj$mapping)==0){
+        text_obj$mapping <- aes_(x=~x, y=~y, label=~label, angle=~angle)
+    }else{
+        text_obj$mapping <- modifyList(text_obj$mapping, aes_(x=~x, y=~y, label=~label, angle=~angle))
+    }
     text_dot_params <- switch(object$geom,
                              text= reset_dot_params(mapping=text_obj$mapping,
                                             defaultp=params,
@@ -278,8 +286,24 @@ build_text_layer <- function(data, object, params){
         object$parse <- FALSE
     }
     text_obj <- c(text_obj, text_dot_params)
+    if (object$geom == "text"){
+        if (layout %in% c("circular", "radial", "daylight", "fan", "unrooted", "ape", "inward_circular", "equal_angle") && 
+            (is.null(object$params$horizontal) || object$params$horizontal)){
+            m1 <- aes_string(subset="(angle < 90 | angle > 270)", angle="angle")
+            m2 <- aes_string(subset="(angle >= 90 & angle <=270)", angle="angle+180")
+            m1 <- modifyList(text_obj$mapping, m1)
+            m2 <- modifyList(text_obj$mapping, m2)
+            text_obj1 <- text_obj2 <- text_obj
+            text_obj1$mapping <- m1
+            text_obj2$mapping <- m2
+            text_obj2$hjust <- 1
+            textlayer <- list(do.call("geom_text2", text_obj1), do.call("geom_text2", text_obj2))
+        }else{
+            textlayer <- do.call("geom_text", text_obj)
+        }
+    }
     text_obj <- switch(object$geom,
-                       text = do.call("geom_text", text_obj),
+                       text = textlayer, #do.call("geom_text", text_obj),
                        label = do.call("geom_label", text_obj),
                        shadowtext = do.call("label_geom", text_obj)
                       )

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -258,7 +258,8 @@ ggplot_add.tiplab_ylab <- function(object, plot, object_name) {
 ##' @method ggplot_add cladelabel
 ##' @export
 ggplot_add.cladelabel <- function(object, plot, object_name) {
-    layout <- get("layout", envir = plot$plot_env)
+    #layout <- get("layout", envir = plot$plot_env)
+    layout <- get_layout(plot)
     if (layout == "unrooted" || layout == "daylight") {
         ly <- do.call(geom_cladelabel2, object)
     } else {
@@ -270,7 +271,8 @@ ggplot_add.cladelabel <- function(object, plot, object_name) {
 ##' @method ggplot_add cladelab
 ##' @export
 ggplot_add.cladelab <- function(object, plot, object_name){
-    layout <- get("layout", envir=plot$plot_env)
+    #layout <- get("layout", envir=plot$plot_env)
+    layout <- get_layout(plot)
     if (is.null(object$mapping) && (is.null(object$node) || is.null(object$label))){
         abort("mapping and node or label can't be NULL simultaneously, we can't get the
               data to be displayed in this layer, please provide a data or subset, node 
@@ -358,7 +360,7 @@ ggplot_add.cladelab <- function(object, plot, object_name){
                        )
     bar_obj <- list()
     bar_obj$data <- bardata
-    bar_default_aes <- list(barcolour="black", barcolor="black", barsize=0.5, colour="black", size=0.5, linetype=1, alpha=NA)
+    bar_default_aes <- list(barcolour="black", barcolor="black", barsize=0.5, colour="black", size=0.5, linetype=1, alpha=NA, inherit.aes=FALSE)
     bar_obj$mapping <- reset_mapping(defaultm=bar_default_aes, inputm=object$mapping)
     ifelse(is.null(bar_obj$mapping),bar_obj$mapping <- aes_(x=~x, xend=~xend, y=~y, yend=~yend),
            bar_obj$mapping <- modifyList(bar_obj$mapping, aes_(x=~x, xend=~xend, y=~y, yend=~yend)))
@@ -402,7 +404,8 @@ ggplot_add.cladelab <- function(object, plot, object_name){
 ##' @importFrom rlang quo_name
 ##' @export
 ggplot_add.hilight <- function(object, plot, object_name){
-    layout <- get("layout", envir = plot$plot_env)
+    #layout <- get("layout", envir = plot$plot_env)
+    layout <- get_layout(plot)
     if (!is.character(layout)) layout <- "rectangular"
     if (is.null(object$mapping) && is.null(object$node)){
         abort("mapping and node can't be NULL simultaneously, we can't get the 
@@ -577,7 +580,8 @@ ggplot_add.scale_ggtree <- function(object, plot, object_name) {
 ##' @importFrom rlang abort as_name
 ##' @export
 ggplot_add.taxalink <- function(object, plot, object_name){
-    layout <- get("layout", envir = plot$plot_env)
+    #layout <- get("layout", envir = plot$plot_env)
+    layout <- get_layout(plot)
     if (object$outward=="auto"){
        if(layout=="inward_circular"){
            object$outward <- FALSE

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -352,8 +352,8 @@ ggplot_add.cladelab <- function(object, plot, object_name){
         object$mapping <- object$mapping[!names(object$mapping) %in% c("node", "label")]
     }
     annot_obj <- switch(object$geom,
-                        text=build_text_layer(data=textdata, object=object, params=text_params),
-                        label=build_text_layer(data=textdata, object=object, params=text_params),
+                        text=build_text_layer(data=textdata, object=object, params=text_params, layout=layout),
+                        label=build_text_layer(data=textdata, object=object, params=text_params, layout=layout),
                         image=build_image_layer(data=textdata, object=object, params=image_params),
                         phylopic=build_image_layer(data=textdata, object=object, params=image_params),
                         shadowtext=build_text_layer(data=textdata, object=object, params=text_params),

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -293,13 +293,21 @@ ggplot_add.cladelab <- function(object, plot, object_name){
                        set subset (we will extract the data from tree data.)")
             }
         }else{
+            #trda <- plot$data[,!colnames(plot$data) %in% c("parent", "branch.length", "x", "y", "branch", "angle")]
+            samevars <- Reduce(intersect,list(extract_all_aes_var(object$mapping), colnames(plot$data), colnames(object$data)))
+            object$data <- merge(object$data, plot$data, by.x=quo_name(object$mapping$node), by.y="node", all.x=TRUE)
+            if (length(samevars) > 0){
+                warning_wrap('The "', paste(samevars, collapse=", ") ,'" has(have) been found in tree data. You might need to 
+                             rename the variable(s) in the data of "geom_cladelab" to avoid this warning!')
+                object$mapping <- remapping(mapping=object$mapping, samevars=samevars)
+            }
             if (!is.null(object$mapping$subset)){
                 object$data <- subset(object$data, eval(parse(text=quo_name(object$mapping$subset))))
                 object$mapping <- object$mapping[names(object$mapping)!="subset"]
             }
         }
-        da_node_label <- data.frame(node=as.vector(object$data[[as_name(object$mapping$node)]]),
-                                    label=as.vector(object$data[[as_name(object$mapping$label)]]))
+        da_node_label <- data.frame(node=as.vector(object$data[[quo_name(object$mapping$node)]]),
+                                    label=as.vector(object$data[[quo_name(object$mapping$label)]]))
     }else{
         da_node_label <-data.frame(node=object$node, label=object$label)
     }
@@ -432,6 +440,16 @@ ggplot_add.hilight <- function(object, plot, object_name){
                        set subset (we will extract the data from tree data.)")
              }
         }else{
+             if (!flag_tbl_tree){
+                 #trda <- plot$data[,!colnames(plot$data) %in% c("parent", "branch.length", "x", "y", "branch", "angle")]
+                 samevars <- Reduce(intersect,list(extract_all_aes_var(object$mapping), colnames(plot$data), colnames(object$data)))
+                 object$data <- merge(object$data, plot$data, by.x=quo_name(object$mapping$node), by.y="node", all.x=TRUE)
+                 if (length(samevars) > 0){
+                     warning_wrap('The "', paste(samevars, collapse=", ") ,'" has(have) been found in tree data. You might need to 
+                                  rename the variable(s) in the data of "geom_hilight" to avoid this warning!')
+                     object$mapping <- remapping(mapping=object$mapping, samevars=samevars)
+                 }
+             }
              if (!is.null(object$mapping$subset)){
                  object$data <- subset(object$data, eval(parse(text=quo_name(object$mapping$subset))))
                  object$mapping <- object$mapping[names(object$mapping)!="subset"]


### PR DESCRIPTION
+ don't inherit the global `aes` in `geom_cladelab` and `geom_taxalink`.
   - when global `mapping` of `ggtree` has `color` or `size`, if `geom_cladelab` and `geom_taxalink` will return error since the
      variables  `color` of `size` is not found. and extract `layout` using `get_layout` to solve the problem  #393.
+ optimize the angle of text in geom_cladelab.
   - the related issue #130 

```
library(ggtree)
set.seed(123)
my_tree <- rtree(50)
clade_df <- data.frame(node = c(66, 75, 80, 94),
                      clade = paste0("clade_", 1:4)
                    )

p <- ggtree(my_tree,
            layout = "fan"
            )

p1 <- p +
      geom_cladelab(data=clade_df,
                    mapping=aes(
                               node=node,
                               label=clade
                               ),
                    angle="auto"
                   )
p1
```
![better_angle1](https://user-images.githubusercontent.com/17870644/117424712-a842dd00-af54-11eb-9106-bb9a4256ff6a.png)
```

clade_df2 <- data.frame(node = c(66, 75, 80, 94),
                       clade = paste0("clade_", 1:4),
                       horizontal=c(FALSE, FALSE, TRUE, TRUE),
                       hjust=c(0.5, 0.5, 0, 0),
                       vjust=c(1, 1, 0.5, 0.5)
                       )


p2 <- p +
      geom_cladelab(data=clade_df2,
                    mapping=aes(
                               node=node,
                               label=clade,
                               horizontal=horizontal,
                               hjust=hjust,
                               vjust=vjust

                              ),
                    angle="auto"
                   )
p2
```
![better_angle2](https://user-images.githubusercontent.com/17870644/117424793-c27cbb00-af54-11eb-83de-ba262b8a9eb8.png)
