### PR TITLE
ignore negative edge introduce options(ignore.negative.edge=TRUE)

### DIFF
--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -769,7 +769,7 @@ getXcoord2 <- function(x, root, parent, child, len, start=0, rev=FALSE) {
                   ifelse(sum(len < 0)>1, "edge lengths", "edge length"),
                   ". If you want to ignore the ", 
                   ifelse(sum(len<0) > 1, "edges", "edge"),
-                  "you can set 'options(ignore.negative.edge=TRUE)', then re-run ggtree."
+                  ", you can set 'options(ignore.negative.edge=TRUE)', then re-run ggtree."
         )
     }
 


### PR DESCRIPTION
+ introduce options(ignore.negative.edge=TRUE) to ignore the negative edges
   default is FALSE

```
> library(ggtree)
ggtree v3.1.5.900  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics, 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> set.seed(123)
> tr <- rtree(10)
> tr$edge.length[10] <- -1 * tr$edge.length[10]
> p <- tr %>% ggtree()
Warning message:
The tree contained negative edge length. If you want to ignore the edgeyou
can set 'options(ignore.negative.edge=TRUE)', then re-run ggtree.
> p
```

```
> options(ignore.negative.edge=TRUE)
> p <- tr %>% ggtree()
> p
```
![xx2](https://user-images.githubusercontent.com/17870644/136920123-7b8c870f-ffc7-45c1-8313-b5fe2d87201f.PNG)

```
> options(ignore.negative.edge=TRUE)
> set.seed(123)
> d <- matrix(rnorm(100), 10)
> xx <- hclust(as.dist(d))
> tr2 <- ape::as.phylo(xx)
> p2 <- tr2 %>% ggtree(layout="dend")  +
                           geom_tiplab(hjust=0.5, vjust=1) +
                           theme_dendrogram()
> library(ggplotify)
> as.ggplot(~plot(xx)) + p2
```
![xx3](https://user-images.githubusercontent.com/17870644/136920376-c25b9129-c4db-4c16-b7cf-0112ef3a6575.PNG)
