### PR TITLE
Add outline to nodepies

### DIFF
--- a/R/inset.R
+++ b/R/inset.R
@@ -119,7 +119,7 @@ nodebar <- function(data, cols, color, alpha=1, position="stack") {
 ##' @return list of ggplot objects
 ##' @export
 ##' @author Guangchuang Yu
-nodepie <- function(data, cols, color, alpha=1) {
+nodepie <- function(data, cols, color, alpha=1, outline.color="transparent", outline.size=0) {
     if (! "node" %in% colnames(data)) {
         stop("data should have a column 'node'...")
     }
@@ -128,14 +128,14 @@ nodepie <- function(data, cols, color, alpha=1) {
         color <- NA
     }
     ldf <- gather(data, type, value, !! cols) %>% split(., .$node)
-    lapply(ldf, function(df) ggpie(df, y=~value, fill=~type, color, alpha))
+    lapply(ldf, function(df) ggpie(df, y=~value, fill=~type, color, alpha, outline.color, outline.size))
 }
 
 
 ##' @importFrom methods missingArg
-ggpie <- function(data, y, fill, color, alpha=1) {
+ggpie <- function(data, y, fill, color, alpha=1, outline.color="transparent", outline.size=0) {
     p <- ggplot(data, aes_(x=1, y=y, fill=fill)) +
-        geom_bar(stat='identity', alpha=alpha) +
+        geom_bar(stat='identity', alpha=alpha, color=outline.color, size=outline.size, show.legend = F) +
         coord_polar(theta='y') + theme_inset()
 
     if (missingArg(color) || is.null(color) || is.na(color)) {

--- a/R/theme.R
+++ b/R/theme.R
@@ -121,7 +121,7 @@ theme_tree2_internal <- function(bgcolor="white", fgcolor="black",
 theme_inset <- function(legend.position =  "none", ...) {
     list(xlab(NULL),
          ylab(NULL),
-         theme_tree(legend.position = legend.position, ...),
+         theme_tree(legend.position = legend.position, plot.margin = unit(c(0, 0, 0, 0), "lines"), ...),
          ggfun::theme_transparent()
          )
 }


### PR DESCRIPTION
These small changes allow to add outline to nodepies. Outlines can be customized changing the color (outline.color) and size (outline.size). I also suggest that theme_inset make the inset plot to have no margins, the inset is thus displayed slightly bigger on the whole plot, which is more convenient to fine tune the size of an inset when the size has to be very low (i.e. `width` and `height` 0.001 to 0.1 in `geom_inset()`).