### PR TITLE
Remove Remotes dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,8 +52,6 @@ Suggests:
     testthat,
     tibble,
     glue
-Remotes:
-    GuangchuangYu/treeio
 VignetteBuilder: knitr
 ByteCompile: true
 Encoding: UTF-8


### PR DESCRIPTION
We currently can't install `ggtree` offline, because it has a Remotes dependency on `treeio`. However, `treeio` is also included in Imports, so we should be able to remove it from Remotes.