### PR TITLE
Fix #582 Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,8 +52,6 @@ Suggests:
     testthat,
     tibble,
     glue
-Remotes:
-    YuLab-SMU/treeio
 VignetteBuilder: knitr
 ByteCompile: true
 Encoding: UTF-8


### PR DESCRIPTION
Stops forcing treeio to be installed from github when running in renv, by removing the explicit 'Remote:' specification