### PR TITLE
Expose position argument for `geom_range()`

### DIFF
--- a/R/geom_range.R
+++ b/R/geom_range.R
@@ -18,8 +18,7 @@ geom_range <- function(range, center = "auto", ...) {
 }
 
 
-geom_range_internal <- function(range, center, mapping=NULL, ...) {
-    position = "identity"
+geom_range_internal <- function(range, center, mapping=NULL, position = "identity", ...) {
     show.legend = NA
     na.rm = TRUE
     inherit.aes = FALSE


### PR DESCRIPTION
This exposes the `position` argument for `geom_range()` so you can do something like the following:

```r
library(ggplot2)
library(ggtree)
library(treeio)
library(deeptime)

file <- system.file("extdata/BEAST", "beast_mcc.tree", package="treeio")
beast <- read.beast(file)

ggtree(beast, position = position_nudge(x = -500))  +
  geom_range(range='length_0.95_HPD', color='red', alpha=.6, size=2,
                  position = position_nudge(x = -500)) +
  scale_x_continuous(breaks = seq(-500, -460, 10), labels = abs(seq(-500, -460, 10))) +
  theme_tree2() +
  coord_geo(pos = list("bottom", "bottom"), dat = list("stages", "periods"),
            neg = TRUE, ylim = c(0, NA), center_end_labels = TRUE, abbrv = list(TRUE, FALSE))
```
![image](https://github.com/YuLab-SMU/ggtree/assets/7232514/e0ba6c47-5581-4f23-9051-c46a0961b76a)

This is particularly useful for plotting trees that are made up of entirely extinct taxa which you need to bump backwards in time (since ggtree puts the root at 0).