### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     purrr,
     rlang,
     ggfun (>= 0.1.5),
-    yulab.utils (>= 0.1.5.002),
+    yulab.utils (>= 0.1.5),
     tidyr,
     tidytree (>= 0.4.5),
     treeio (>= 1.8.0),


### PR DESCRIPTION
Fixed namespace issue. Requirement for yulab.utils >= 0.1.5.002 prevented package loading in R 4.2.0 with both ggtree and yulab.utils installed from github. Appears to be working now.