### PR TITLE
Added support for XStringSet in msaplot

### DIFF
--- a/R/msaplot.R
+++ b/R/msaplot.R
@@ -29,6 +29,19 @@ msaplot <- function(p, fasta, offset=0, width=1, color=NULL, window=NULL, bg_lin
         x <- fasta
     } else if (is(fasta, "character")) {
         x <- treeio::read.fasta(fasta)
+    } else if (is(fasta, "BStringSet")) {
+        if (requireNamespace("Biostrings", quietly = TRUE) == TRUE) {
+          temp_fasta <- tempfile("temp_fasta", fileext = ".fasta")
+          Biostrings::writeXStringSet(fasta, temp_fasta)
+          
+          x <- treeio::read.fasta(temp_fasta)
+      } else {
+          stop("object is of class 'BStringSet' but library 'Biostrings' is not installed...\n-> please install 'Biostrings' from https://bioconductor.org/packages/Biostrings for handling objects of type 'BStringSet'.")
+      }
+    } else if (is(fasta, "DNAStringSet")) {
+        x <- ape::as.DNAbin(fasta)
+    } else if (is(fasta, "AAStringSet")) {
+        x <- ape::as.AAbin(fasta)
     } else {
         x <- NULL
     }


### PR DESCRIPTION
**Description**

Added support for [XStringSet](https://bioconductor.org/packages/release/bioc/html/Biostrings.html) objects (i.e., `BStringSet`, `AAStringSet` and `DNAStringSet`) for function `msaplot()` in response to #626. The problem came up because an [old example on R-Bloggers](https://www.r-bloggers.com/2016/08/ggtree-for-microbiome-data/) does not work anymore.

In the proposed solution, if the object is of type `BStringSet` it is first checked, if library `Biostrings` is installed. If so, a temporary file is created and read via `treeio::read.fasta()` to circumvent the need to check if it as amino acid or DNA sequence. Otherwise it throws a helpful error message. `AAStringSet` and `DNAStringSet` objects are converted using functions from the `ape` package.

**Tests**


```
library(ggtree)
library(Biostrings)
library(phyloseq)
library(ggplot2)
library(scales)


data(GlobalPatterns)
GP <- prune_taxa(taxa_sums(GlobalPatterns) > 0, GlobalPatterns)
GP.chl <- subset_taxa(GP, Phylum=="Chlamydiae")

p <- ggtree(GP.chl, ladderize = FALSE) + geom_text2(aes(subset=!isTip, label=label), hjust=-.2, size=4) +
  geom_tiplab(aes(label=Genus), hjust=-.3) +
  geom_point(aes(x=x+hjust, color=SampleType, shape=Family, size=Abundance),na.rm=TRUE) +
  scale_size_continuous(trans=log_trans(5)) +
  theme(legend.position="right") 

df <- fortify(GP.chl)
barcode <- as.character(df$Barcode_full_length)
names(barcode) <- df$label
barcode <- barcode[!is.na(barcode)]

#With Biostrings installed
##XStringSets
bss_barcode <- Biostrings::BStringSet(barcode)
p1 <- p + ggtitle("reproduce phyloseq by ggtree, BStringSet")
msaplot(p1, bss_barcode, width=.3, offset=.05)
ggsave("plots/bss.svg", height = 9)

aass_barcode <- AAStringSet(bss_barcode)
p2 <- p + ggtitle("reproduce phyloseq by ggtree, AAStringSet")
msaplot(p2, aass_barcode, width=.3, offset=.05)
ggsave("plots/aass.svg", height = 9)

dnass_barcode <- DNAStringSet(bss_barcode)
p3 <- p + ggtitle("reproduce phyloseq by ggtree, DNAStringSet")
msaplot(p3, dnass_barcode, width=.3, offset=.05)
ggsave("plots/dnass.svg", height = 9)


##XXX.bin
aabin_barcode <- ape::as.AAbin(aass_barcode)
p4 <- p + ggtitle("reproduce phyloseq by ggtree, AABin")
msaplot(p4, aabin_barcode, width=.3, offset=.05)
ggsave("plots/aabin.svg", height = 9)

dnabin_barcode <- ape::as.DNAbin(dnass_barcode)
p5 <- p + ggtitle("reproduce phyloseq by ggtree, DNABin")
msaplot(p5, dnabin_barcode, width=.3, offset=.05)
ggsave("plots/dnabin.svg", height = 9)


##file
writeXStringSet(bss_barcode, "fastafile.fasta")
p6 <- p + ggtitle("reproduce phyloseq by ggtree, file")
msaplot(p6, "fastafile.fasta", width=.3, offset=.05)
ggsave("plots/file.svg", height = 9)


#Without Biostrings installed
unloadNamespace("phyloseq")
unloadNamespace("Biostrings")
remove.packages("Biostrings")


##XStringSet
a <- list("ABC")
class(a) <- "BStringSet"
p7 <- p + ggtitle("reproduce phyloseq by ggtree, BStringSet without Biostrings")
msaplot(p7, a, width=.3, offset=.05)

#Error in msaplot(p7, a, width = 0.3, offset = 0.05) : 
#object is of class 'BStringSet' but library 'Biostrings' is not installed...
#-> please install 'Biostrings' from https://bioconductor.org/packages/Biostrings for handling objects of type 'BStringSet'.
```

The function produces the expected outcome:

![bss](https://github.com/user-attachments/assets/288943a7-9e37-448b-87c1-9c5537cdcd59)
![aass](https://github.com/user-attachments/assets/32a566d0-32c9-48a2-b3fa-9db9d859dd90)
![dnass](https://github.com/user-attachments/assets/b2349a59-935d-4617-aa12-23eebc5ff825)
![file](https://github.com/user-attachments/assets/948e6491-edf5-4f59-b6a1-cca0f9e903ce)
![aabin](https://github.com/user-attachments/assets/e60b817e-4405-43e7-b707-35714dfed155)
![dnabin](https://github.com/user-attachments/assets/3f75cab3-8d57-422d-8006-2dc750bc2cda)

