### PR TITLE
Replace `check_linewidth()`

### DIFF
--- a/R/geom_hilight.R
+++ b/R/geom_hilight.R
@@ -306,7 +306,16 @@ geom_hilight_encircle2 <- function(data=NULL,
           )
 }
 
-check_linewidth <- getFromNamespace('check_linewidth', 'ggplot2')
+check_linewidth <- function(data, name) {
+  if (is.null(data$linewidth) && !is.null(data$size)) {
+    warning(paste0(
+      "Using the `size` aesthetic with ", name, " was deprecated in ggplot2 3.4.0.\n",
+      "Please use the `linewidth` aesthetic instead."
+    ))
+    data$linewidth <- data$size
+  }
+  data
+}
 snake_class <- getFromNamespace('snake_class', 'ggplot2')
 snakeize <- getFromNamespace('snakeize', 'ggplot2')
 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is due to accessing ggplot2 internals that aren't meant for public consumption, see also https://www.tidyverse.org/blog/2022/09/playing-on-the-same-team-as-your-dependecy/.

This PR replaces one such instance that will become broken, there are several other instances of this as well. The best practise around this is to copy the internal functions into your own package.

I also noticed a few other warnings popping up that you might want to take a look at. You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun