### PR TITLE
Changed usage of adjust_hclust_tip_edge_len to match updated function…

### DIFF
--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -68,7 +68,7 @@ fortify.phylo <- function(model, data,
         res <- calculate_angle(res)
     }
     res <- scaleY(as.phylo(model), res, yscale, layout, ...)
-    res <- adjust_hclust_tip.edge.len(res, x, layout, branch.length)
+    res <- adjust_hclust_tip_edge_len(res, x, layout, branch.length)
     class(res) <- c("tbl_tree", class(res))
     attr(res, "layout") <- layout
     return(res)


### PR DESCRIPTION
The function adjust_hclust_tip.edge.len was renamed to adjust_hclust_tip_edge_len a few days ago, but it was called using the outdated name elsewhere which of course threw an error.