### PR TITLE
fix issue of geom_taxalink because of outward argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     tidytree (>= 0.4.5),
     treeio (>= 1.8.0),
     utils,
-    yulab.utils (>= 0.1.6)
+    yulab.utils (>= 0.2.3)
 Suggests:
     emojifont,
     ggimage,

--- a/R/geom_taxalink.R
+++ b/R/geom_taxalink.R
@@ -178,7 +178,7 @@ GeomCurvelink <- ggproto("GeomCurvelink", GeomSegment,
   required_aes = c("x", "y", "xend", "yend"),
   default_aes = aes(colour = "black", linewidth = 0.5, linetype = 1, alpha = NA, curvature=0.5, hratio=1, ncp=1, curveangle=90, square=FALSE),
   rename_size = TRUE,
-  make_curvelink_data = function(data, panel_params, coord) {
+  make_curvelink_data = function(data, panel_params, coord, outward = TRUE) {
     if (!coord$is_linear()) {
         tmpgroup <- data$group
         starts <- subset(data, select = c(-xend, -yend))
@@ -213,7 +213,7 @@ GeomCurvelink <- ggproto("GeomCurvelink", GeomSegment,
   },
   draw_panel = function(data, panel_params, coord, shape=0.5, outward=TRUE,
                         arrow = NULL, arrow.fill=NULL, lineend = "butt", na.rm = FALSE) {
-    trans <- GeomCurvelink$make_curvelink_data(data, panel_params, coord)
+    trans <- GeomCurvelink$make_curvelink_data(data, panel_params, coord, outward)
     arrow.fill <- arrow.fill %|||% trans$colour
 
     grobs <- lapply(seq_len(nrow(trans)), function(i){
@@ -329,7 +329,7 @@ GeomInteractiveCurvelink <- ggproto(
        )
     }
 
-    trans <- GeomCurvelink$make_curvelink_data(data, panel_params, coord)
+    trans <- GeomCurvelink$make_curvelink_data(data, panel_params, coord, outward)
     arrow.fill <- arrow.fill %|||% trans$colour
 
     grobs <- lapply(seq_len(nrow(trans)), function(i){


### PR DESCRIPTION
The related issue #691 

```
> library(ggtree)
ggtree v4.1.1.001 Learn more at https://yulab-smu.top/contribution-tree-data/

Please cite:

Guangchuang Yu. Using ggtree to visualize data on tree-like structures.
Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96
> tree <- read.tree("https://bioconnector.github.io/workshops/data/tree_newick.nwk")
> tree

Phylogenetic tree with 13 tips and 12 internal nodes.

Tip labels:
  A, B, C, D, E, F, ...

Rooted; includes branch length(s).
> ggtree(tree, layout='circ') + geom_tiplab() +geom_taxalink(taxa1 = "E", taxa2= "H", color='blue3', hratio=3)
```
<img width="429" height="380" alt="image" src="https://github.com/user-attachments/assets/03177b31-ae83-4dfb-875e-9b1f709db81a" />
